### PR TITLE
fix: respect BATT_STAT

### DIFF
--- a/components/ble_new/hid_device_le_prf.c
+++ b/components/ble_new/hid_device_le_prf.c
@@ -575,13 +575,14 @@ void esp_hidd_prf_cb_hdl(esp_gatts_cb_event_t event, esp_gatt_if_t gatts_if,
 			(hidd_le_env.hidd_cb)(ESP_HIDD_EVENT_BLE_CONNECT, &cb_param);
 
 		}
+#ifdef BATT_STAT
 		battary_lev = get_battery_level();
 		ESP_LOGI(HID_LE_PRF_TAG, "set battery value on conn %d, hanlde %d, value %d, length %d\n", 
 		 		param->connect.conn_id, battery_table[BAS_IDX_BATT_LVL_VAL], battary_lev, sizeof(battary_lev));
 		esp_ble_gatts_set_attr_value(battery_table[BAS_IDX_BATT_LVL_VAL], sizeof(uint8_t), &battary_lev);
 		esp_ble_gatts_send_indicate(gatts_if, param->connect.conn_id, battery_table[BAS_IDX_BATT_LVL_VAL], 
 				sizeof(uint8_t), &battary_lev, false);
-
+#endif
 
 		break;
 	}


### PR DESCRIPTION

Despite undefining `BATT_STAT`, the code crashes upon pairing inside `get_battery_level`:

```
I (1824) ESP-NOW: Initialing ESP-NOW
I (1828) ESPNOW: espnow [version: 1.0] init
I (1832) ESPNOW: initializezd
I (1836) Keyboard task: initializezd
I (1840) Sleep: initializezd
I (1918) HID_LE_PRF: HID connection establish, conn_id = 0
I (1919) hal_ble: ESP_HIDD_EVENT_BLE_CONNECT
assertion "chars != NULL" failed: file "/tmp/esp/esp-idf/components/esp_adc_cal/esp_adc_cal.c", line 347, function: esp_adc_cal_raw_to_voltage
abort() was called at PC 0x400d7283 on core 0

ELF file SHA256: ac0e52dac30d7a764d301267cab7eb201c0099efc88b4303f30b02a59aba7bcc

Backtrace: 0x4008bf3c:0x3ffd0fe0 0x4008c2dd:0x3ffd1000 0x400d7283:0x3ffd1020 0x4013e90a:0x3ffd1050 0x400d5652:0x3ffd1070 0x400d62bd:0x3ffd1090 0x400d5ff9:0x3ffd10d0 0x400f345e:0x3ffd1100 0x400f3dd2:0x3ffd1120 0x400efb1d:0x3ffd1160 0x401194db:0x3ffd1180

Entering gdb stub now.
$T0b#e6
```

This is due to a missing ifdef. This PR adds it.